### PR TITLE
Readme config addition; Fix hopper flags mixin; Added ability for trusted players to break chests (configurable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,13 @@ Toggles no message mode, which hides non-command messages like automatic protect
 Permission node: `htm.command.quiet`
 
 ### Config
-`canTrustedPlayersBreakChests`: Toggles whether players trusted to a locked container can break the container, set to false by default meaning only the owner can break a locked container.
+`canTrustedPlayersBreakChests`: Toggles whether players trusted to a locked container can break the container
+(set to false by default meaning only the owner can break a locked container).
 
 `defaultFlags`:
     - `hoppers`: Toggles whether hoppers can pull from locked containers by default, true by default meaning hoppers can pull from locked containers.
-`autolockingContainers`: List of containers which will be set to PRIVATE by default, remove or comment out items in the list to make them set to public by default.
+`autolockingContainers`: List of containers which will be set to PRIVATE by default
+(remove or comment out items in the list to make them set to public by default).
 
 ### Additional permissions
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Permission node: `htm.command.quiet`
 
 `autolockingContainers`: List of containers which will be set to PRIVATE by default
 
-    (remove or comment out items in the list to make them set to public by default).
+    (remove items in the list to make them set to public by default).
 
 ### Additional permissions
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ Toggles no message mode, which hides non-command messages like automatic protect
 
 Permission node: `htm.command.quiet`
 
+### Config
+`canTrustedPlayersBreakChests`: Toggles whether players trusted to a locked container can break the container, set to false by default meaning only the owner can break a locked container.
+
+`defaultFlags`:
+    - `hoppers`: Toggles whether hoppers can pull from locked containers by default, true by default meaning hoppers can pull from locked containers.
+`autolockingContainers`: List of containers which will be set to PRIVATE by default, remove or comment out items in the list to make them set to public by default.
+
 ### Additional permissions
 
 `htm.admin`: Allows unrestricted access to containers and other managerial permissions

--- a/src/main/java/com/github/fabricservertools/htm/config/HTMConfig.java
+++ b/src/main/java/com/github/fabricservertools/htm/config/HTMConfig.java
@@ -22,7 +22,7 @@ public class HTMConfig {
             .setPrettyPrinting()
             .create();
 
-    public boolean canTrustedPlayersBreakChests;
+    public boolean canTrustedPlayersBreakChests = false;
 
     public final Map<String, Boolean> defaultFlags = new HashMap<>();
 
@@ -56,9 +56,7 @@ public class HTMConfig {
 
     public HTMConfig() {
         defaultFlags.put("hoppers", true);
-        canTrustedPlayersBreakChests = false;
     }
-
 
     public static HTMConfig loadConfig(File file) {
         HTMConfig config;

--- a/src/main/java/com/github/fabricservertools/htm/config/HTMConfig.java
+++ b/src/main/java/com/github/fabricservertools/htm/config/HTMConfig.java
@@ -22,6 +22,8 @@ public class HTMConfig {
             .setPrettyPrinting()
             .create();
 
+    public boolean canTrustedPlayersBreakChests;
+
     public final Map<String, Boolean> defaultFlags = new HashMap<>();
 
     public final ArrayList<Identifier> autolockingContainers = new ArrayList<>(Arrays.asList(
@@ -54,6 +56,7 @@ public class HTMConfig {
 
     public HTMConfig() {
         defaultFlags.put("hoppers", true);
+        canTrustedPlayersBreakChests = false;
     }
 
 

--- a/src/main/java/com/github/fabricservertools/htm/listeners/PlayerEventListener.java
+++ b/src/main/java/com/github/fabricservertools/htm/listeners/PlayerEventListener.java
@@ -55,7 +55,7 @@ public class PlayerEventListener {
 
             if (!lock.isLocked()) return true;
 
-            if (lock.isOwner((ServerPlayerEntity) player)) {
+            if (lock.isOwner((ServerPlayerEntity) player) || (HTM.config.canTrustedPlayersBreakChests && lock.getTrusted().contains(((ServerPlayerEntity) player).getUuid()))) {
                 if (state.getBlock() instanceof LockableChestBlock) {
                     Optional<BlockEntity> unlocked = ((LockableChestBlock) state.getBlock()).getUnlockedPart(state, world, pos);
                     if (unlocked.isPresent()) {
@@ -64,7 +64,6 @@ public class PlayerEventListener {
                         return true;
                     }
                 }
-
 
                 Utility.sendMessage(playerEntity, Text.translatable("text.htm.unlocked"));
 

--- a/src/main/java/com/github/fabricservertools/htm/listeners/PlayerEventListener.java
+++ b/src/main/java/com/github/fabricservertools/htm/listeners/PlayerEventListener.java
@@ -55,7 +55,7 @@ public class PlayerEventListener {
 
             if (!lock.isLocked()) return true;
 
-            if (lock.isOwner((ServerPlayerEntity) player) || (HTM.config.canTrustedPlayersBreakChests && lock.getTrusted().contains(((ServerPlayerEntity) player).getUuid()))) {
+            if (lock.isOwner((ServerPlayerEntity) player) || (HTM.config.canTrustedPlayersBreakChests && lock.getTrusted().contains(player.getUuid()))) {
                 if (state.getBlock() instanceof LockableChestBlock) {
                     Optional<BlockEntity> unlocked = ((LockableChestBlock) state.getBlock()).getUnlockedPart(state, world, pos);
                     if (unlocked.isPresent()) {

--- a/src/main/java/com/github/fabricservertools/htm/mixin/HopperBlockEntityMixin.java
+++ b/src/main/java/com/github/fabricservertools/htm/mixin/HopperBlockEntityMixin.java
@@ -12,37 +12,11 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import java.util.Objects;
 
 @Mixin(HopperBlockEntity.class)
 public abstract class HopperBlockEntityMixin {
-    /*
-	@Redirect(method = "getInventoryAt(Lnet/minecraft/world/World;DDD)Lnet/minecraft/inventory/Inventory;", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getBlockEntity(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/block/entity/BlockEntity;"))
-	private static BlockEntity getProtectedInventory(World world, BlockPos pos) {
-		BlockEntity blockEntity = Objects.requireNonNull(world.getBlockEntity(pos));
-		if (world.isClient) return blockEntity;
-
-		HTMContainerLock lock = InteractionManager.getLock((ServerWorld) world, blockEntity);
-		if (lock == null) {
-			return blockEntity;
-		}
-
-		if (!lock.isLocked()) {
-			return blockEntity;
-		}
-
-		if (lock.getFlags().get("hoppers")) {
-			return blockEntity;
-		}
-
-		return null;
-	}
-    */
-
-    @Inject(method = "extract(Lnet/minecraft/world/World;Lnet/minecraft/block/entity/Hopper;)Z", at = @At("HEAD"), cancellable = true)
+	@Inject(method = "extract(Lnet/minecraft/world/World;Lnet/minecraft/block/entity/Hopper;)Z", at = @At(value = "FIELD", target = "Lnet/minecraft/util/math/Direction;DOWN:Lnet/minecraft/util/math/Direction;", shift = At.Shift.AFTER), cancellable = true)
     private static void extractHTMCheck(World world, Hopper hopper, CallbackInfoReturnable<Boolean> cir) {
         // only checks extraction, so only needs to check block above hopper
         if (!isBlockContainerHopperable(world, new BlockPos(hopper.getHopperX(), hopper.getHopperY(), hopper.getHopperZ()).offset(Direction.UP)))
@@ -50,6 +24,7 @@ public abstract class HopperBlockEntityMixin {
         // otherwise continue the extract method as normal
     }
 
+	//TODO optimize better
     private static boolean isBlockContainerHopperable(World world, BlockPos pos) {
         if (world.isClient) return true;
 

--- a/src/main/java/com/github/fabricservertools/htm/mixin/HopperBlockEntityMixin.java
+++ b/src/main/java/com/github/fabricservertools/htm/mixin/HopperBlockEntityMixin.java
@@ -3,18 +3,23 @@ package com.github.fabricservertools.htm.mixin;
 import com.github.fabricservertools.htm.HTMContainerLock;
 import com.github.fabricservertools.htm.interactions.InteractionManager;
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.Hopper;
 import net.minecraft.block.entity.HopperBlockEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Objects;
 
 @Mixin(HopperBlockEntity.class)
 public abstract class HopperBlockEntityMixin {
+    /*
 	@Redirect(method = "getInventoryAt(Lnet/minecraft/world/World;DDD)Lnet/minecraft/inventory/Inventory;", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getBlockEntity(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/block/entity/BlockEntity;"))
 	private static BlockEntity getProtectedInventory(World world, BlockPos pos) {
 		BlockEntity blockEntity = Objects.requireNonNull(world.getBlockEntity(pos));
@@ -35,4 +40,24 @@ public abstract class HopperBlockEntityMixin {
 
 		return null;
 	}
+    */
+
+    @Inject(method = "extract(Lnet/minecraft/world/World;Lnet/minecraft/block/entity/Hopper;)Z", at = @At("HEAD"), cancellable = true)
+    private static void extractHTMCheck(World world, Hopper hopper, CallbackInfoReturnable<Boolean> cir) {
+        // only checks extraction, so only needs to check block above hopper
+        if (!isBlockContainerHopperable(world, new BlockPos(hopper.getHopperX(), hopper.getHopperY(), hopper.getHopperZ()).offset(Direction.UP)))
+            cir.setReturnValue(true); // if block is not hopperable, cancel the extract method call
+        // otherwise continue the extract method as normal
+    }
+
+    private static boolean isBlockContainerHopperable(World world, BlockPos pos) {
+        if (world.isClient) return true;
+
+        BlockEntity blockEntity = world.getBlockEntity(pos);
+        if (blockEntity == null) // no block entity above
+            return true;
+
+        HTMContainerLock lock = InteractionManager.getLock((ServerWorld) world, blockEntity);
+        return lock == null || !lock.isLocked() || lock.getFlags().get("hoppers");
+    }
 }


### PR DESCRIPTION
Fixed the mixin for HopperBlockEntity which, at least in my testing, was not actually preventing hoppers from siphoning from containers locked and flagged false for hoppers.

I also added the ability in the config to allow trusted players to break chests instead of just the owner per
https://github.com/QuiltServerTools/HeyThatsMine/issues/22
https://github.com/QuiltServerTools/HeyThatsMine/issues/31
This is set to false by default currently as I did not want to change expected behavior.

I also added a section for config to the readme.