### PR TITLE
Update to 1.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21-pre4
-yarn_mappings=1.21-pre4+build.3
+minecraft_version=1.21
+yarn_mappings=1.21+build.1
 loader_version=0.15.11
 # Mod Properties
 mod_version=1.1.13
@@ -11,5 +11,5 @@ maven_group=us.potatoboy
 archives_base_name=htm
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.100.0+1.21
+fabric_version=0.100.1+1.21
 translation_version=2.3.1+1.21-pre2

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20.5
-yarn_mappings=1.20.5+build.1
-loader_version=0.15.10
+minecraft_version=1.21-pre4
+yarn_mappings=1.21-pre4+build.3
+loader_version=0.15.11
 # Mod Properties
-mod_version=1.1.12
+mod_version=1.1.13
 maven_group=us.potatoboy
 archives_base_name=htm
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.97.6+1.20.5
-translation_version=2.3.0+1.20.5-rc2
+fabric_version=0.100.0+1.21
+translation_version=2.3.1+1.21-pre2

--- a/src/main/java/com/github/fabricservertools/htm/config/HTMConfig.java
+++ b/src/main/java/com/github/fabricservertools/htm/config/HTMConfig.java
@@ -27,31 +27,31 @@ public class HTMConfig {
     public final Map<String, Boolean> defaultFlags = new HashMap<>();
 
     public final ArrayList<Identifier> autolockingContainers = new ArrayList<>(Arrays.asList(
-            new Identifier("chest"),
-            new Identifier("trapped_chest"),
-            new Identifier("barrel"),
+            Identifier.of("chest"),
+            Identifier.of("trapped_chest"),
+            Identifier.of("barrel"),
 
-            new Identifier("furnace"),
-            new Identifier("blast_furnace"),
-            new Identifier("smoker"),
+            Identifier.of("furnace"),
+            Identifier.of("blast_furnace"),
+            Identifier.of("smoker"),
 
-            new Identifier("shulker_box"),
-            new Identifier("white_shulker_box"),
-            new Identifier("orange_shulker_box"),
-            new Identifier("magenta_shulker_box"),
-            new Identifier("light_blue_shulker_box"),
-            new Identifier("yellow_shulker_box"),
-            new Identifier("lime_shulker_box"),
-            new Identifier("pink_shulker_box"),
-            new Identifier("gray_shulker_box"),
-            new Identifier("light_gray_shulker_box"),
-            new Identifier("cyan_shulker_box"),
-            new Identifier("purple_shulker_box"),
-            new Identifier("blue_shulker_box"),
-            new Identifier("brown_shulker_box"),
-            new Identifier("green_shulker_box"),
-            new Identifier("red_shulker_box"),
-            new Identifier("black_shulker_box")
+            Identifier.of("shulker_box"),
+            Identifier.of("white_shulker_box"),
+            Identifier.of("orange_shulker_box"),
+            Identifier.of("magenta_shulker_box"),
+            Identifier.of("light_blue_shulker_box"),
+            Identifier.of("yellow_shulker_box"),
+            Identifier.of("lime_shulker_box"),
+            Identifier.of("pink_shulker_box"),
+            Identifier.of("gray_shulker_box"),
+            Identifier.of("light_gray_shulker_box"),
+            Identifier.of("cyan_shulker_box"),
+            Identifier.of("purple_shulker_box"),
+            Identifier.of("blue_shulker_box"),
+            Identifier.of("brown_shulker_box"),
+            Identifier.of("green_shulker_box"),
+            Identifier.of("red_shulker_box"),
+            Identifier.of("black_shulker_box")
     ));
 
     public HTMConfig() {

--- a/src/main/java/com/github/fabricservertools/htm/world/data/GlobalTrustState.java
+++ b/src/main/java/com/github/fabricservertools/htm/world/data/GlobalTrustState.java
@@ -2,7 +2,6 @@ package com.github.fabricservertools.htm.world.data;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import net.fabricmc.fabric.api.util.NbtType;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtHelper;
@@ -22,13 +21,13 @@ public class GlobalTrustState extends PersistentState {
 	public static GlobalTrustState fromNbt(NbtCompound tag,
 			RegistryWrapper.WrapperLookup registryLookup) {
 		GlobalTrustState trustState = new GlobalTrustState();
-		NbtList trustList = tag.getList("GlobalTrusts", NbtType.COMPOUND);
+		NbtList trustList = tag.getList("GlobalTrusts", NbtElement.COMPOUND_TYPE);
 
 		trustList.forEach(tag1 -> {
 			NbtCompound compoundTag = (NbtCompound) tag1;
 			UUID truster = compoundTag.getUuid("Truster");
 
-			NbtList trustedTag = compoundTag.getList("Trusted", NbtType.INT_ARRAY);
+			NbtList trustedTag = compoundTag.getList("Trusted", NbtElement.INT_ARRAY_TYPE);
 
 			for (NbtElement value : trustedTag) {
 				trustState.globalTrust.put(truster, NbtHelper.toUuid(value));

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,6 @@
   "depends": {
     "fabricloader": ">=0.12.3",
     "fabric": "*",
-    "minecraft": ">=1.20.4"
+    "minecraft": ">=1.21"
   }
 }


### PR DESCRIPTION
The following changes have been made:

- All versions in `gradle.properties` have been updated to the latest versions for 1.21 pre-release 4.
- As the constructor of `Identifier` is now private, every `new Identifier` call has been replaced with `Identifier.of`.
- Usage of the deprecated constants in `NbtType` have been replaced with the vanilla constants in the `NbtElement` class.

Mod is able to build fine and from a little bit of testing everything seems to work okay. Locked containers seem to transfer over correctly.
Draft PR will be turned into a PR when 1.21 releases on Thursday.