### PR TITLE
Fix trusted player break check

### DIFF
--- a/src/main/java/com/github/fabricservertools/htm/listeners/PlayerEventListener.java
+++ b/src/main/java/com/github/fabricservertools/htm/listeners/PlayerEventListener.java
@@ -55,7 +55,7 @@ public class PlayerEventListener {
 
             if (!lock.isLocked()) return true;
 
-            if (lock.isOwner((ServerPlayerEntity) player) || (HTM.config.canTrustedPlayersBreakChests && lock.isTrusted(player.getUuid()))) {
+            if (lock.isOwner(playerEntity) || (HTM.config.canTrustedPlayersBreakChests && lock.canOpen(playerEntity))) {
                 if (state.getBlock() instanceof LockableChestBlock) {
                     Optional<BlockEntity> unlocked = ((LockableChestBlock) state.getBlock()).getUnlockedPart(state, world, pos);
                     if (unlocked.isPresent()) {


### PR DESCRIPTION
Fixes a bug where global-trusted players cannot break containers, even when `canTrustedPlayersBreakChests` is set to true.