### PR TITLE
Update to 1.21.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
     modImplementation include("xyz.nucleoid:server-translations-api:${project.translation_version}")
 
-    modImplementation include("me.lucko:fabric-permissions-api:0.2-SNAPSHOT")
+    modImplementation include("me.lucko:fabric-permissions-api:${project.permissions_api_version}")
 
     modImplementation include("eu.pb4:common-protection-api:1.0.0")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.4-pre3
-yarn_mappings=1.21.4-pre3+build.2
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.1
 loader_version=0.16.9
 # Mod Properties
 mod_version=1.1.15
@@ -11,6 +11,6 @@ maven_group=us.potatoboy
 archives_base_name=htm
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.110.2+1.21.4
+fabric_version=0.110.5+1.21.4
 translation_version=2.4.0+1.21.2-rc1
 permissions_api_version=0.3.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,15 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.3
-yarn_mappings=1.21.3+build.1
-loader_version=0.16.7
+minecraft_version=1.21.4-pre3
+yarn_mappings=1.21.4-pre3+build.2
+loader_version=0.16.9
 # Mod Properties
-mod_version=1.1.14
+mod_version=1.1.15
 maven_group=us.potatoboy
 archives_base_name=htm
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.106.1+1.21.3
+fabric_version=0.110.2+1.21.4
 translation_version=2.4.0+1.21.2-rc1
+permissions_api_version=0.3.3

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.16.9",
-    "fabric": "*",
+    "fabric": "1.21.4",
     "minecraft": "1.21.4-beta.3"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,8 +23,8 @@
     "htm.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.16.7",
+    "fabricloader": ">=0.16.9",
     "fabric": "*",
-    "minecraft": ">=1.21.2 <=1.21.3"
+    "minecraft": "1.21.4-beta.3"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
   ],
   "depends": {
     "fabricloader": ">=0.16.9",
-    "fabric": "1.21.4",
-    "minecraft": "1.21.4-beta.3"
+    "fabric": "*",
+    "minecraft": "1.21.4"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,6 @@
   "depends": {
     "fabricloader": ">=0.16.9",
     "fabric": "*",
-    "minecraft": "1.21.4"
+    "minecraft": ">=1.21.4"
   }
 }


### PR DESCRIPTION
Updated to 1.21.4. No changes were required other than dependency updates. Along with Minecraft (to 1.21.4) and Fabric API (to 0.110.2), the permissions API has also been updated (to 0.3.3).

Basic testing has been done and everything seems to work okay. Will do more testing later and mark PR as ready when 1.21.4 has released next week.